### PR TITLE
Prevent crashing if message.addresses() is empty

### DIFF
--- a/smsapp/conversationmodel.cpp
+++ b/smsapp/conversationmodel.cpp
@@ -141,8 +141,11 @@ void ConversationModel::createRowFromMessage(const ConversationMessage& message,
                 << "Ignoring duplicate message with ID" << message.uID();
         return;
     }
-
-    ConversationAddress sender = message.addresses().first();
+    
+    ConversationAddress sender;
+    if (!message.addresses().isEmpty()) {
+        sender = message.addresses().first();
+    }
     QString senderName = message.isIncoming() ? SmsHelper::getTitleForAddresses({sender}) : QString();
     QString displayBody = message.body();
 


### PR DESCRIPTION
This should fix the bug described in [https://bugs.kde.org/show_bug.cgi?id=449719](https://bugs.kde.org/show_bug.cgi?id=449719)