### PR TITLE
Add delay so it has no issue on Emacs's paste

### DIFF
--- a/plugins/mousepad/x11remoteinput.cpp
+++ b/plugins/mousepad/x11remoteinput.cpp
@@ -14,7 +14,7 @@
 #else
 #include <private/qtx11extras_p.h>
 #endif
-
+#include<unistd.h>
 #include <X11/extensions/XTest.h>
 #include <X11/keysym.h>
 #include <fakekey/fakekey.h>
@@ -184,6 +184,7 @@ bool X11RemoteInput::handlePacket(const NetworkPacket &np)
                 for (int i = 0; i < key.length(); i++) {
                     QByteArray utf8 = QString(key.at(i)).toUtf8();
                     fakekey_press(m_fakekey, (const uchar *)utf8.constData(), utf8.size(), 0);
+                    sleep(0.001);
                     fakekey_release(m_fakekey);
                 }
             }

--- a/plugins/mousepad/x11remoteinput.cpp
+++ b/plugins/mousepad/x11remoteinput.cpp
@@ -184,7 +184,7 @@ bool X11RemoteInput::handlePacket(const NetworkPacket &np)
                 for (int i = 0; i < key.length(); i++) {
                     QByteArray utf8 = QString(key.at(i)).toUtf8();
                     fakekey_press(m_fakekey, (const uchar *)utf8.constData(), utf8.size(), 0);
-                    sleep(0.001);
+                    sleep(0.001); // Add delay to prevent keys transposed in X11 programs like Emacs
                     fakekey_release(m_fakekey);
                 }
             }


### PR DESCRIPTION
The compose has issue to send to Emacs due to keyboard simulation in X11 has issue with Emacs which causes the characters to randomly transposed.

Adding this delay solves it. Might be better with some configuration parameter so the delay it's not a magic number.