### PR TITLE
Fix segfault when SMS thread has zero messages

### DIFF
--- a/plugins/sms/requestconversationworker.cpp
+++ b/plugins/sms/requestconversationworker.cpp
@@ -52,8 +52,8 @@ void RequestConversationWorker::handleRequestConversation()
 
         size_t numCachedMessages = messagesList.count();
         size_t requestEnd = start + numHandled;
-        size_t numRemainingMessages = numCachedMessages - requestEnd;
-        double percentRemaining = ((double)numRemainingMessages / numCachedMessages) * 100;
+        size_t numRemainingMessages = numCachedMessages > requestEnd ? numCachedMessages - requestEnd : 0;
+        double percentRemaining = numCachedMessages > 0 ? ((double)numRemainingMessages / numCachedMessages) * 100 : 0;
 
         if (percentRemaining < CACHE_LOW_WATER_MARK_PERCENT || numRemainingMessages < MIN_NUMBER_TO_REQUEST) {
             parent->updateConversation(conversationID);
@@ -65,6 +65,10 @@ void RequestConversationWorker::handleRequestConversation()
 
 size_t RequestConversationWorker::replyForConversation(const QList<ConversationMessage> &conversation, size_t start, size_t howMany)
 {
+    if (conversation.isEmpty() || start >= (size_t)conversation.size()) {
+        return 0;
+    }
+
     // Messages are sorted in ascending order of keys, meaning the front of the list has the oldest
     // messages (smallest timestamp number)
     // Therefore, return the end of the list first (most recent messages)


### PR DESCRIPTION
## Description
Fixes a crash (Segmentation Fault) in `kdeconnect_sms.so` when an Android device sends an SMS thread with zero messages (like an empty draft). 

The crash occurs because:
1. `messagesList` is empty, so `messagesList.count()` is 0.
2. In the `else` block, calculating `percentRemaining` divides by `numCachedMessages` (which is 0), leading to a crash on some architectures.
3. In `replyForConversation`, it adds `start` to `conversation.crbegin()` on an empty list, which creates an out-of-bounds iterator and evaluates undefined behavior when comparing against `crend()`.

This patch checks for empty conversations early and prevents division by zero.

## Testing
Verified that `kdeconnectd` no longer segfaults with the message `Got a conversationID for a conversation with no messages! 28`.